### PR TITLE
Add config classes for API tokens and .env support 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,4 @@ error-screenshots/
 webpack.generated.js
 
 postgres.env
+.env

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,13 @@
             <scope>runtime</scope>
         </dependency>
 
+        <!-- load env variables -->
+        <dependency>
+            <groupId>me.paulschwarz</groupId>
+            <artifactId>spring-dotenv</artifactId>
+            <version>4.0.0</version>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-jpa</artifactId>

--- a/src/main/java/com/clashofserres/cinematch/Application.java
+++ b/src/main/java/com/clashofserres/cinematch/Application.java
@@ -8,6 +8,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.sql.init.SqlDataSourceScriptDatabaseInitializer;
 import org.springframework.boot.autoconfigure.sql.init.SqlInitializationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 
 /**
@@ -18,6 +19,7 @@ import org.springframework.context.annotation.Bean;
  *
  */
 @SpringBootApplication
+@EnableConfigurationProperties
 @Theme(value = "cinematch", variant = Lumo.DARK)
 public class Application implements AppShellConfigurator {
 

--- a/src/main/java/com/clashofserres/cinematch/config/HuggingFaceConfig.java
+++ b/src/main/java/com/clashofserres/cinematch/config/HuggingFaceConfig.java
@@ -1,0 +1,19 @@
+package com.clashofserres.cinematch.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "huggingface.api")
+public class HuggingFaceConfig {
+
+    private String token;
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+}

--- a/src/main/java/com/clashofserres/cinematch/config/LuxandConfig.java
+++ b/src/main/java/com/clashofserres/cinematch/config/LuxandConfig.java
@@ -1,0 +1,19 @@
+package com.clashofserres.cinematch.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "luxand.api")
+public class LuxandConfig {
+
+    private String token;
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+}

--- a/src/main/java/com/clashofserres/cinematch/config/TmdbConfig.java
+++ b/src/main/java/com/clashofserres/cinematch/config/TmdbConfig.java
@@ -1,0 +1,28 @@
+package com.clashofserres.cinematch.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "tmdb.api")
+public class TmdbConfig {
+
+    private String key;
+    private String token;
+
+    public String getKey() {
+        return key;
+    }
+
+    public void setKey(String key) {
+        this.key = key;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public void setToken(String token) {
+        this.token = token;
+    }
+}

--- a/src/main/java/com/clashofserres/cinematch/config/package-info.java
+++ b/src/main/java/com/clashofserres/cinematch/config/package-info.java
@@ -1,0 +1,1 @@
+package com.clashofserres.cinematch.config;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,3 +28,11 @@ spring.jpa.show-sql=true
 vaadin.allowed-packages = com.vaadin,org.vaadin,com.flowingcode,com.clashofserres.cinematch
 spring.jpa.defer-datasource-initialization = true
 spring.sql.init.mode = always
+
+
+#Secrets
+# The values are fetched from the .env file.
+tmdb.api.key=${TMDB_API_KEY}
+tmdb.api.token=${TMDB_API_TOKEN}
+luxand.api.token=${LUXAND_API_TOKEN}
+huggingface.api.token=${HUGGING_FACE_API_TOKEN}


### PR DESCRIPTION
Introduced configuration classes for HuggingFace, Luxand, and TMDB API tokens, and enabled property binding in the main application. Added the spring-dotenv dependency to load environment variables and updated application.properties to reference API secrets from the .env file. 